### PR TITLE
Remove macos tests

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -18,16 +18,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "ubuntu-latest", "macos-latest", "windows-latest" ]
+        os: [ "ubuntu-latest", "windows-latest" ]
         python-version: [ "3.7", "3.8", "3.9" ]
         include:
           - os: ubuntu-latest
             label: linux-64
             prefix: /usr/share/miniconda3/envs/my-env
-
-          - os: macos-latest
-            label: osx-64
-            prefix: /Users/runner/miniconda3/envs/my-env
 
           - os: windows-latest
             label: win-64


### PR DESCRIPTION
Remove failing macos tests.

These tests are failing because of OS config issues. They'll be added back once I figure out why they suddenly started failing with "abort trap 6" errors